### PR TITLE
Adaptive theme

### DIFF
--- a/ipyplot/_html_helpers.py
+++ b/ipyplot/_html_helpers.py
@@ -419,12 +419,12 @@ def _get_default_style(img_width: int, zoom_scale: float):
 
         div.ipyplot-content-div-%(0)s {
             width: %(1)spx;
-            background: white;
+            background: var(--jp-layout-color0);
             display: inline-block;
             vertical-align: top;
             text-align: center;
             position: relative;
-            border: 2px solid #ddd;
+            border: var(--jp-border-width) solid var(--jp-cell-editor-border-color);
             top: 0;
             left: 0;
         }


### PR DESCRIPTION
I'm currently using the following css to make the ipyplot html match the user jupyter theme as well as make the text visible in dark themes (dracula shown below).

```
[class^="ipyplot-content-div-"] {
    background: var(--jp-layout-color0) !important;
    border: var(--jp-border-width) solid var(--jp-cell-editor-border-color) !important;
}
```

Before:
![image](https://user-images.githubusercontent.com/55400948/106987775-27374680-67a9-11eb-854c-6256830f8ab6.png)
After:
![image](https://user-images.githubusercontent.com/55400948/106987803-36b68f80-67a9-11eb-8d36-6512b37e6c1d.png)

This PR should make this the default. The only concern I have is usage outside of the jupyter environment or versions missing these vars.