### PR TITLE
Fix argument name in `plot_class_tabs` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ images = [
     "docs/example3-classes.jpg",
 ]
 labels = ['class1', 'class2', 'class3']
-ipyplot.plot_class_tabs(images, labels, max_images_per_tab=10, img_width=150)
+ipyplot.plot_class_tabs(images, labels, max_imgs_per_tab=10, img_width=150)
 
 ```
 


### PR DESCRIPTION
The `plot_class_tabs` example has the wrong argument name `max_images_per_tab`. I updated `README.md` to the show the correct name: `max_imgs_per_tab`.