### PR TITLE
remove usages of numpy float, Fixes #50

### DIFF
--- a/ipyplot/_img_helpers.py
+++ b/ipyplot/_img_helpers.py
@@ -75,7 +75,7 @@ def _img_to_base64(
     """  # NOQA E501
     # if statements to convert image to PIL.Image object
     if isinstance(image, np.ndarray):
-        if image.dtype in [np.float, np.float32, np.float64]:
+        if image.dtype in [np.float32, np.float64]:
             # if dtype is float and values range is from 0.0 to 1.0
             # we need to normalize it to 0-255 range
             image = image * 255 if image.max() <= 1.0 else image

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -45,7 +45,7 @@ TEST_DATA = [
     (np.asarray(BASE_NP_IMGS), LABELS[1], LABELS[0]),
     (np.asarray(BASE_INTERNET_URLS), LABELS[1], LABELS[0]),
     (np.asarray(BASE_LOCAL_URLS), LABELS[1], LABELS[0]),
-    (np.asarray(BASE_NP_IMGS, dtype=np.float) / 255, LABELS[1], LABELS[0]),
+    (np.asarray(BASE_NP_IMGS, dtype=np.float32) / 255, LABELS[1], LABELS[0]),
     (LOCAL_URLS_AS_PIL, LABELS[0], LABELS[0]),
     (LOCAL_URLS_AS_PIL, LABELS[1], LABELS[1]),
     (LOCAL_URLS_AS_PIL, LABELS[2], LABELS[2]),


### PR DESCRIPTION
as numpy deprecated `np.float`, I'm suggesting here to remove both uses of it. Error and solution reference - https://stackoverflow.com/questions/74844262/how-to-solve-error-numpy-has-no-attribute-float-in-python. Also tries to fix #50 